### PR TITLE
Ability to install git version via pip (git+https://github.com/Malith-Rukshan/Suno-API/)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[project]
+name = "SunoAPI"
+version = "v1.0.8"
+authors = [
+  { name="Malith Rukshan" },
+]
+description = "Suno API Python Wrapper"
+readme = "README.md"
+requires-python = ">=3.8"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Operating System :: OS Independent",
+]
+
+[project.urls]
+Homepage = "https://github.com/Malith-Rukshan/Suno-API"
+Issues = "https://github.com/Malith-Rukshan/Suno-API/issues"


### PR DESCRIPTION
Apparently there is a "pyproject.toml" missing in the repository, so pip refused to install "development" versions.

```
(.venv) abc@services:~/workspace$ pip install git+https://github.com/Malith-Rukshan/Suno-API/
Collecting git+https://github.com/Malith-Rukshan/Suno-API/
  Cloning https://github.com/Malith-Rukshan/Suno-API/ to /tmp/pip-req-build-5njmw9k9
  Running command git clone --filter=blob:none --quiet https://github.com/Malith-Rukshan/Suno-API/ /tmp/pip-req-build-5njmw9k9
  Resolved https://github.com/Malith-Rukshan/Suno-API/ to commit c789c3359d2cc6b70d09ac289c681050bd805ca9
ERROR: git+https://github.com/Malith-Rukshan/Suno-API/ does not appear to be a Python project: neither 'setup.py' nor 'pyproject.toml' found.
```

With this, the install works fine, please adapt the values, I only used my best guess of what I could find. ;-)